### PR TITLE
Q3 - Calculate conversions using true and markup rates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "react-dom": "^18.3.1",
                 "react-router-dom": "^6.24.1",
                 "react-scripts": "5.0.1",
+                "use-debounce": "^10.0.2",
                 "web-vitals": "^4.2.1"
             }
         },
@@ -20652,6 +20653,17 @@
                 "requires-port": "^1.0.0"
             }
         },
+        "node_modules/use-debounce": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.2.tgz",
+            "integrity": "sha512-MwBiJK2dk+2qhMDVDCPRPeLuIekKfH2t1UYMnrW9pwcJJGFDbTLliSMBz2UKGmE1PJs8l3XoMqbIU1MemMAJ8g==",
+            "engines": {
+                "node": ">= 16.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -36706,6 +36718,12 @@
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
             }
+        },
+        "use-debounce": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.2.tgz",
+            "integrity": "sha512-MwBiJK2dk+2qhMDVDCPRPeLuIekKfH2t1UYMnrW9pwcJJGFDbTLliSMBz2UKGmE1PJs8l3XoMqbIU1MemMAJ8g==",
+            "requires": {}
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.24.1",
         "react-scripts": "5.0.1",
+        "use-debounce": "^10.0.2",
         "web-vitals": "^4.2.1"
     },
     "scripts": {

--- a/src/Components/Calculations/Calculations.jsx
+++ b/src/Components/Calculations/Calculations.jsx
@@ -1,13 +1,25 @@
+import PropTypes from 'prop-types';
+import Price from '../../Components/Price';
 import { convert } from "../../utils/convert";
+import classes from './Calculations.module.css';
 
 const Calculations = (props) => {
-    const { amount, exchangeRate } = props;
+    const { amount, currency, exchangeRate } = props;
+
+    const { base, ofx } = convert(amount, exchangeRate);
 
     return (
         <div aria-live="polite">
-            {convert(amount, exchangeRate)}
+            <p>Base: <Price value={base} currency={currency} className={classes.price} /></p>
+            <p>OFX: <Price value={ofx} currency={currency} className={classes.price} /></p>
         </div>
     )
+}
+
+Calculations.propTypes = {
+    amount: PropTypes.string.isRequired,
+    currency: PropTypes.string.isRequired,
+    exchangeRate: PropTypes.number.isRequired
 }
 
 export default Calculations;

--- a/src/Components/Calculations/Calculations.jsx
+++ b/src/Components/Calculations/Calculations.jsx
@@ -1,0 +1,13 @@
+import { convert } from "../../utils/convert";
+
+const Calculations = (props) => {
+    const { amount, exchangeRate } = props;
+
+    return (
+        <div aria-live="polite">
+            {convert(amount, exchangeRate)}
+        </div>
+    )
+}
+
+export default Calculations;

--- a/src/Components/Calculations/Calculations.jsx
+++ b/src/Components/Calculations/Calculations.jsx
@@ -6,7 +6,7 @@ import classes from './Calculations.module.css';
 const Calculations = (props) => {
     const { amount, currency, exchangeRate } = props;
 
-    const { base, ofx } = convert(amount, exchangeRate);
+    const { base, ofx } = convert({ amount, exchangeRate });
 
     return (
         <div aria-live="polite">

--- a/src/Components/Calculations/Calculations.module.css
+++ b/src/Components/Calculations/Calculations.module.css
@@ -1,0 +1,4 @@
+.price {
+    font-size: 1.3em;
+    margin-inline-start: 10px;
+}

--- a/src/Components/Calculations/index.js
+++ b/src/Components/Calculations/index.js
@@ -1,0 +1,1 @@
+export { default } from './Calculations'

--- a/src/Components/Input/Input.jsx
+++ b/src/Components/Input/Input.jsx
@@ -1,14 +1,28 @@
+import PropTypes from 'prop-types';
+import { useDebouncedCallback } from 'use-debounce';
+import { useConversionContext } from '../../context/ConversionContext'
 import classes from './Input.module.css';
 
 const Input = (props) => {
 
+    const { setAmount } = useConversionContext();
+
+    const debouncedUpdate = useDebouncedCallback(
+        value => props.onUpdate(value),
+        300
+    );
+
     return (
         <div>
             <label htmlFor="amount">Amount</label>
-            <input type="text" name="amount" id="amount" className={classes.input} />
+            <input type="tel" pattern="[0-9]+" name="amount" id="amount" className={classes.input} onChange={e => debouncedUpdate(e.target.value)} required />
         </div>
     )
 
 }
+
+Input.propTypes = {
+    onUpdate: PropTypes.func
+};
 
 export default Input;

--- a/src/Components/Input/Input.module.css
+++ b/src/Components/Input/Input.module.css
@@ -1,12 +1,3 @@
-.container {
-    display: flex;
-    flex-direction: column;
-    position: relative;
-    max-width: 400px;
-    font-family: 'Nunito Sans';
-    color: #0b1a3f;
-}
-
 .input {
     display: flex;
     justify-content: flex-start;
@@ -19,4 +10,5 @@
     border-radius: 4px;
     padding: 1px 6px;
     font-size: 16px;
+    box-sizing: border-box;
 }

--- a/src/Components/Price/Price.jsx
+++ b/src/Components/Price/Price.jsx
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import countryToCurrency from '../../Libs/CountryCurrency.json';
+
+const Price = (props) => {
+    const { value, currency, className } = props;
+
+    if (isNaN(value)) {
+        return <span>⚠️ Input isn't a number</span>;
+    }
+
+    const price = new Intl.NumberFormat(currency, { style: 'currency', currency: countryToCurrency[currency] }).format(
+        value,
+      )
+
+    return (
+        <span className={className}>{price}</span>
+    )
+}
+
+Price.propTypes = {
+    value: PropTypes.number.isRequired,
+    currency: PropTypes.string.isRequired,
+    className: PropTypes.string
+}
+
+export default Price;

--- a/src/Components/Price/index.js
+++ b/src/Components/Price/index.js
@@ -1,0 +1,1 @@
+export { default } from './Price';

--- a/src/Layouts/MainLayout.jsx
+++ b/src/Layouts/MainLayout.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import Header from './Header';
 import Menu from './Menu';
 
+import ConversionContext from '../context/ConversionContext';
+
 import './MainLayout.css';
 
 const MainLayout = (props) => {
@@ -11,7 +13,9 @@ const MainLayout = (props) => {
             <Menu />
             <div id="main">
                 <Header title={props.title} />
-                <div id="content">{props.children}</div>
+                <ConversionContext>
+                    <div id="content">{props.children}</div>
+                </ConversionContext>
             </div>
         </div>
     );

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
+import Calculations from '../../Components/Calculations';
 import DropDown from '../../Components/DropDown';
 import Input from '../../Components/Input';
 import ProgressBar from '../../Components/ProgressBar';
 import Loader from '../../Components/Loader';
+
+import { useConversionContext } from '../../context/ConversionContext';
 
 import { useAnimationFrame } from '../../Hooks/useAnimationFrame';
 import { ReactComponent as Transfer } from '../../Icons/Transfer.svg';
@@ -109,7 +112,19 @@ const Rates = () => {
                 />
 
                 <div className={classes.rowWrapper}>
+                    <div style={{ marginRight: '20px' }}>
                         <Input onUpdate={setAmount} />
+                    </div>
+
+                    <div className={classes.exchangeWrapper}>
+                        <div className={classes.transferIcon}>
+                            <Transfer height={'25px'} />
+                        </div>
+                        <div className={classes.rate} style={{ visibility: 'hidden' }}>{exchangeRate}</div>
+                    </div>
+                    <div style={{ marginLeft: '20px' }}>
+                        <Calculations amount={amount} exchangeRate={exchangeRate} />
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -18,9 +18,9 @@ const Rates = () => {
     const [fromCurrency, setFromCurrency] = useState('AU');
     const [toCurrency, setToCurrency] = useState('US');
 
-    const [exchangeRate, setExchangeRate] = useState(0.7456);
     const [progression, setProgression] = useState(0);
     const [loading, setLoading] = useState(false);
+    const { amount, setAmount, exchangeRate, setExchangeRate } = useConversionContext();
 
     const Flag = ({ code }) => (
         <img alt={code || ''} src={`/img/flags/${code || ''}.svg`} width="20px" className={classes.flag} />
@@ -109,7 +109,7 @@ const Rates = () => {
                 />
 
                 <div className={classes.rowWrapper}>
-                    <Input />
+                        <Input onUpdate={setAmount} />
                 </div>
             </div>
         </div>

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -123,7 +123,7 @@ const Rates = () => {
                         <div className={classes.rate} style={{ visibility: 'hidden' }}>{exchangeRate}</div>
                     </div>
                     <div style={{ marginLeft: '20px' }}>
-                        <Calculations amount={amount} exchangeRate={exchangeRate} />
+                        <Calculations amount={amount} currency={toCurrency} exchangeRate={exchangeRate} />
                     </div>
                 </div>
             </div>

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -50,7 +50,14 @@ const Rates = () => {
     return (
         <div className={classes.container}>
             <div className={classes.content}>
-                <div className={classes.heading}>Currency Conversion</div>
+                <div className={classes.heading}>
+                    Currency Conversion
+                    {loading && (
+                        <div className={classes.loaderWrapper}>
+                            <Loader width={'25px'} height={'25px'} />
+                        </div>
+                    )}
+                </div>
 
                 <div className={classes.rowWrapper}>
                     <div>
@@ -104,12 +111,6 @@ const Rates = () => {
                 <div className={classes.rowWrapper}>
                     <Input />
                 </div>
-
-                {loading && (
-                    <div className={classes.loaderWrapper}>
-                        <Loader width={'25px'} height={'25px'} />
-                    </div>
-                )}
             </div>
         </div>
     );

--- a/src/Pages/Rates/Rates.module.css
+++ b/src/Pages/Rates/Rates.module.css
@@ -30,6 +30,7 @@
     display: flex;
     flex-direction: row;
     margin-inline-end: 20px;
+    align-items: center;
 }
 .exchangeWrapper {
     display: flex;

--- a/src/Pages/Rates/Rates.module.css
+++ b/src/Pages/Rates/Rates.module.css
@@ -20,6 +20,10 @@
     line-height: 33px;
     width: 100%;
     margin-bottom: 5px;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 5px;
 }
 
 .rowWrapper {
@@ -57,7 +61,6 @@
 .loaderWrapper {
     display: flex;
     justify-content: center;
-    margin-top: 20px;
 }
 .slow {
     transition: all 1s cubic-bezier(0.55, 0.055, 0.675, 0.19) !important;

--- a/src/context/ConversionContext.jsx
+++ b/src/context/ConversionContext.jsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, useMemo, useState } from 'react';
+
+export const ConversionContext = createContext();
+
+const ConversationContextProvider = (props) => {
+    const [amount, setAmount] = useState(0);
+    const [exchangeRate, setExchangeRate] = useState(0.7456);
+
+    const value = useMemo(() => ({
+        exchangeRate,
+        setExchangeRate,
+        amount,
+        setAmount
+    }), [exchangeRate, amount])
+
+    return (
+        <ConversionContext.Provider value={value}>
+            {props.children}
+        </ConversionContext.Provider>
+    )
+}
+
+export default ConversationContextProvider  ;
+export const useConversionContext = () => useContext(ConversionContext)

--- a/src/utils/__tests__/convert.test.js
+++ b/src/utils/__tests__/convert.test.js
@@ -1,0 +1,15 @@
+import { convert } from '../convert'
+
+describe('convert', () => {
+    it('should convert floating numbercorrectly', () => {
+        const { base, ofx } = convert({ amount: 100, exchangeRate: 0.74 });
+        expect(base).toBe(74);
+        expect(ofx).toBe(73.63);
+    });
+
+    it('should convert round number correctly', () => {
+        const { base, ofx } = convert({ amount: 100, exchangeRate: 1 });
+        expect(base).toBe(100);
+        expect(ofx).toBe(99.5);
+    });
+})

--- a/src/utils/__tests__/get-ofx-rate.test.js
+++ b/src/utils/__tests__/get-ofx-rate.test.js
@@ -1,0 +1,16 @@
+import { getOFXRate } from '../get-ofx-rate';
+describe('getOFXRate', () => {
+    it('calculates appropriate rate', () => {
+        const baseRate = 1;
+        const ofxRate = getOFXRate(baseRate);
+        const expectedRate = 0.995;
+        expect(ofxRate).toBe(expectedRate);
+    })
+
+    it('calculates appropriate rate', () => {
+        const baseRate = 50;
+        const ofxRate = getOFXRate(baseRate);
+        const expectedRate = 49.75;
+        expect(ofxRate).toBe(expectedRate);
+    })
+})

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1,4 +1,17 @@
-export const convert = (amount, rate) => {
+const ofxMarkup = 0.05;
 
-    return amount * rate;
+/**
+ * Convert a given amount using the flat rate, but also the OFX mark up rate
+ * 
+ * @param {number} amount
+ * @param {number} exchangeRate
+ * @returns {{ base: number, ofx: number }}
+ */
+export const convert = (amount, exchangeRate) => {
+    const ofxRate = exchangeRate - (exchangeRate * ofxMarkup);
+
+    return {
+        base: amount * exchangeRate,
+        ofx: amount * ofxRate
+    };
 }

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1,0 +1,7 @@
+export const convert = (amount, rate) => {
+    if (isNaN(amount)) {
+        return "⚠️ Input isn't a number"
+    }
+
+    return amount * rate;
+}

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1,7 +1,4 @@
 export const convert = (amount, rate) => {
-    if (isNaN(amount)) {
-        return "⚠️ Input isn't a number"
-    }
 
     return amount * rate;
 }

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1,4 +1,4 @@
-const ofxMarkup = 0.05;
+import { getOFXRate } from './get-ofx-rate'
 
 /**
  * Convert a given amount using the flat rate, but also the OFX mark up rate
@@ -9,7 +9,7 @@ const ofxMarkup = 0.05;
  * @returns {{ base: number, ofx: number }}
  */
 export const convert = ({ amount, exchangeRate }) => {
-    const ofxRate = exchangeRate - (exchangeRate * ofxMarkup);
+    const ofxRate = getOFXRate(exchangeRate);
 
     return {
         base: amount * exchangeRate,

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -3,11 +3,12 @@ const ofxMarkup = 0.05;
 /**
  * Convert a given amount using the flat rate, but also the OFX mark up rate
  * 
- * @param {number} amount
- * @param {number} exchangeRate
+ * @param {object} opts
+ * @param {number} opts.amount
+ * @param {number} opts.exchangeRate
  * @returns {{ base: number, ofx: number }}
  */
-export const convert = (amount, exchangeRate) => {
+export const convert = ({ amount, exchangeRate }) => {
     const ofxRate = exchangeRate - (exchangeRate * ofxMarkup);
 
     return {

--- a/src/utils/get-ofx-rate.js
+++ b/src/utils/get-ofx-rate.js
@@ -1,0 +1,5 @@
+const ofxMarkup = 0.005;
+
+export const getOFXRate = (baseRate) => {
+    return baseRate - (baseRate * ofxMarkup);
+}


### PR DESCRIPTION
I've left the Input component as uncontrolled, because we don't need to feed a value to it (at this stage anyway, so saving on having to manage extra state). Instead, the component has been updated to "announce" a new value using a debounce. Potentially overkill, but this will save on CPU cycles if the user hasn't yet finished entering their value to convert.

Preview
![image](https://github.com/user-attachments/assets/77458ede-616d-4c58-8f60-859bc89bff28)

I chose to use a context in order to share some necessary data across multiple components, but also attempted to refrain from tying too many components to that context. The Price component, for example, doesn't need to rely on a context, so it receives its data from props. The Calculations component is also set up this way, but in hindsight, perhaps we could hook into the context from this component, as it will avoid the prop drilling that has been introduced.

The calculations have been implemented in basic util JS files, so that they can be easily unit tested. I believe there is a typo in the README that contains examples of conversions.. That is, Example 1 says, 
```
which makes the OFX rate `1.00 - 0.005 = 99.995`
```
This is the part that I believe is a typo, so I've adjusted the expected output in my code to be what I think was supposed to be written in the README

I took a couple of liberties with regards to the UI. For example, the loading indicator has been moved next to the title of the page. This is so that it's less intrusive, while still giving the user a bit of information that something is happening in the background

![image](https://github.com/user-attachments/assets/0a742f8c-1336-4223-a23b-ce91cbb400b0)



