### PR TITLE
Q4 - Dynamically update rate

### DIFF
--- a/src/Components/Calculations/Calculations.jsx
+++ b/src/Components/Calculations/Calculations.jsx
@@ -4,12 +4,12 @@ import { convert } from "../../utils/convert";
 import classes from './Calculations.module.css';
 
 const Calculations = (props) => {
-    const { amount, currency, exchangeRate } = props;
+    const { amount, currency, exchangeRate, className } = props;
 
     const { base, ofx } = convert({ amount, exchangeRate });
 
     return (
-        <div aria-live="polite">
+        <div aria-live="polite" className={className}>
             <p>Base: <Price value={base} currency={currency} className={classes.price} /></p>
             <p>OFX: <Price value={ofx} currency={currency} className={classes.price} /></p>
         </div>

--- a/src/Components/Input/Input.jsx
+++ b/src/Components/Input/Input.jsx
@@ -15,14 +15,19 @@ const Input = (props) => {
     return (
         <div>
             <label htmlFor="amount">Amount</label>
-            <input type="tel" pattern="[0-9]+" name="amount" id="amount" className={classes.input} onChange={e => debouncedUpdate(e.target.value)} required />
+            <input type="tel" pattern="[0-9]+" name="amount" id="amount" className={classes.input} onChange={e => debouncedUpdate(e.target.value)} required disabled={props.disabled} />
         </div>
     )
 
 }
 
 Input.propTypes = {
-    onUpdate: PropTypes.func
+    onUpdate: PropTypes.func,
+    disabled: PropTypes.bool
 };
+
+Input.defaultProps = {
+    disabled: false
+}
 
 export default Input;

--- a/src/Components/Input/Input.module.css
+++ b/src/Components/Input/Input.module.css
@@ -12,3 +12,7 @@
     font-size: 16px;
     box-sizing: border-box;
 }
+
+.input:disabled {
+    cursor: not-allowed;
+}

--- a/src/Hooks/useAnimationFrame.jsx
+++ b/src/Hooks/useAnimationFrame.jsx
@@ -1,17 +1,17 @@
-import { useRef, useEffect } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 
 export const useAnimationFrame = (run, callback) => {
     const requestRef = useRef();
     const previousTimeRef = useRef();
 
-    const animate = (time) => {
+    const animate = useCallback((time) => {
         if (previousTimeRef.current != undefined) {
             const deltaTime = time - previousTimeRef.current;
             callback(deltaTime);
         }
         previousTimeRef.current = time;
         requestRef.current = requestAnimationFrame(animate);
-    };
+    }, [callback]);
 
     useEffect(() => {
         if (!run) {
@@ -22,5 +22,5 @@ export const useAnimationFrame = (run, callback) => {
         }
 
         return () => cancelAnimationFrame(requestRef.current);
-    }, [run]);
+    }, [run, animate]);
 };

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import Calculations from '../../Components/Calculations';
 import DropDown from '../../Components/DropDown';
 import Input from '../../Components/Input';
@@ -29,7 +29,7 @@ const Rates = () => {
         <img alt={code || ''} src={`/img/flags/${code || ''}.svg`} width="20px" className={classes.flag} />
     );
 
-    const fetchData = () => {
+    const fetchData = useCallback(() => {
         if (!loading) {
             setLoading(true);
 
@@ -38,7 +38,7 @@ const Rates = () => {
                 setLoading(false);
             })
         }
-    };
+    }, [toCurrency, fromCurrency]);
 
     // Demo progress bar moving :)
     useAnimationFrame(!loading, (deltaTime) => {
@@ -50,6 +50,11 @@ const Rates = () => {
             return (prevState + deltaTime * 0.0001) % 1;
         });
     });
+
+    // useEffect(() => {
+    //     fetchData();
+    //     setProgression(0); // Reset progress bar, because we've just requested new data
+    // }, [fromCurrency, toCurrency])
 
     return (
         <div className={classes.container}>

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -22,6 +22,7 @@ let countries = CountryData.CountryCodes;
 const Rates = () => {
     const [fromCurrency, setFromCurrency] = useState('AU');
     const [toCurrency, setToCurrency] = useState('US');
+    const [errorMessage, setErrorMessage] = useState('');
 
     const [progression, setProgression] = useState(0);
     const [loading, setLoading] = useState(false);
@@ -34,15 +35,23 @@ const Rates = () => {
     const fetchData = useCallback(() => {
         if (!loading) {
             setLoading(true);
-            fetchRate({ buyCurrency: toCurrency, sellCurrency: fromCurrency }).then((rate) => {
-                setExchangeRate(rate);
-                setLoading(false);
-            })
+            fetchRate({ buyCurrency: toCurrency, sellCurrency: fromCurrency })
+                .then((rate) => {
+                    setExchangeRate(rate);
+                    setErrorMessage('');
+                })
+                .catch((error) => {
+                    setErrorMessage(error.toString());
+                    setExchangeRate(undefined);
+                })
+                .finally(() => {
+                    setLoading(false);
+                })
         }
     }, [toCurrency, fromCurrency]);
 
     // Demo progress bar moving :)
-    useAnimationFrame(!loading, (deltaTime) => {
+    useAnimationFrame(!loading && errorMessage === '', (deltaTime) => {
         setProgression((prevState) => {
             if (prevState > 0.998) {
                 fetchData();
@@ -68,6 +77,12 @@ const Rates = () => {
                         </div>
                     )}
                 </div>
+
+                {errorMessage !== '' && (
+                    <div className={classes.errorContainer}>
+                        {errorMessage}
+                    </div>
+                )}
 
                 <div className={classes.rowWrapper}>
                     <div>
@@ -120,7 +135,7 @@ const Rates = () => {
 
                 <div className={classes.rowWrapper}>
                     <div style={{ marginRight: '20px' }}>
-                        <Input onUpdate={setAmount} />
+                        <Input onUpdate={setAmount} disabled={errorMessage !== ''} />
                     </div>
 
                     <div className={classes.exchangeWrapper}>
@@ -130,7 +145,7 @@ const Rates = () => {
                         <div className={classes.rate} style={{ visibility: 'hidden' }}>{exchangeRate}</div>
                     </div>
                     <div style={{ marginLeft: '20px' }}>
-                        <Calculations amount={amount} currency={toCurrency} exchangeRate={exchangeRate} />
+                        <Calculations amount={amount} currency={toCurrency} exchangeRate={exchangeRate} className={errorMessage === '' ? '' : classes.hidden} />
                     </div>
                 </div>
             </div>

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -10,6 +10,8 @@ import { useConversionContext } from '../../context/ConversionContext';
 import { useAnimationFrame } from '../../Hooks/useAnimationFrame';
 import { ReactComponent as Transfer } from '../../Icons/Transfer.svg';
 
+import { fetchRate } from '../../services/fetch-rate';
+
 import classes from './Rates.module.css';
 
 import CountryData from '../../Libs/Countries.json';
@@ -32,9 +34,8 @@ const Rates = () => {
     const fetchData = useCallback(() => {
         if (!loading) {
             setLoading(true);
-
-            fetch(`https://rates.staging.api.paytron.com/rate/public?buyCurrency=${countryToCurrency[toCurrency]}&sellCurrency=${countryToCurrency[fromCurrency]}`).then(res => res.json()).then((data) => {
-                setExchangeRate(data.retailRate);
+            fetchRate({ buyCurrency: toCurrency, sellCurrency: fromCurrency }).then((rate) => {
+                setExchangeRate(rate);
                 setLoading(false);
             })
         }

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -29,13 +29,14 @@ const Rates = () => {
         <img alt={code || ''} src={`/img/flags/${code || ''}.svg`} width="20px" className={classes.flag} />
     );
 
-    const fetchData = async () => {
+    const fetchData = () => {
         if (!loading) {
             setLoading(true);
 
-            await new Promise((resolve) => setTimeout(resolve, 2000));
-
-            setLoading(false);
+            fetch(`https://rates.staging.api.paytron.com/rate/public?buyCurrency=${countryToCurrency[toCurrency]}&sellCurrency=${countryToCurrency[fromCurrency]}`).then(res => res.json()).then((data) => {
+                setExchangeRate(data.retailRate);
+                setLoading(false);
+            })
         }
     };
 

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Calculations from '../../Components/Calculations';
 import DropDown from '../../Components/DropDown';
 import Input from '../../Components/Input';
@@ -51,10 +51,10 @@ const Rates = () => {
         });
     });
 
-    // useEffect(() => {
-    //     fetchData();
-    //     setProgression(0); // Reset progress bar, because we've just requested new data
-    // }, [fromCurrency, toCurrency])
+    useEffect(() => {
+        fetchData();
+        setProgression(0); // Reset progress bar, because we've just requested new data
+    }, [fromCurrency, toCurrency])
 
     return (
         <div className={classes.container}>

--- a/src/Pages/Rates/Rates.module.css
+++ b/src/Pages/Rates/Rates.module.css
@@ -65,3 +65,11 @@
 .slow {
     transition: all 1s cubic-bezier(0.55, 0.055, 0.675, 0.19) !important;
 }
+
+.hidden {
+    visibility: hidden;
+}
+
+.errorContainer {
+    color: #B00020;
+}

--- a/src/services/fetch-rate.js
+++ b/src/services/fetch-rate.js
@@ -1,0 +1,15 @@
+import countryToCurrency from '../Libs/CountryCurrency.json';
+
+/**
+ * Fetch rate information from API
+ * 
+ * @param {object} opts
+ * @param {string} opts.buyCurrency  Currency being converted to
+ * @param {string} opts.sellCurrency Currency being converted from
+ * @returns {Promise<string>} The exchange rate for the two currencies
+ */
+export const fetchRate = ({ buyCurrency, sellCurrency }) => {
+    return fetch(`https://rates.staging.api.paytron.com/rate/public?buyCurrency=${countryToCurrency[buyCurrency]}&sellCurrency=${countryToCurrency[sellCurrency]}`)
+        .then(res => res.json())
+        .then((data) => data.retailRate);
+}

--- a/src/services/fetch-rate.js
+++ b/src/services/fetch-rate.js
@@ -10,6 +10,13 @@ import countryToCurrency from '../Libs/CountryCurrency.json';
  */
 export const fetchRate = ({ buyCurrency, sellCurrency }) => {
     return fetch(`https://rates.staging.api.paytron.com/rate/public?buyCurrency=${countryToCurrency[buyCurrency]}&sellCurrency=${countryToCurrency[sellCurrency]}`)
-        .then(res => res.json())
-        .then((data) => data.retailRate);
+        .then(async res => {
+            const body = await res.json();
+
+            if (res.ok) {
+                return body.retailRate;
+            }
+            
+            throw new Error(body.detail)
+        });
 }


### PR DESCRIPTION
Implement the _seemingly_ simple dynamic rate lookup when the progress bar is filled.

There was a bug within the application that meant the first fetch request after the currencies (the values in the drop downs) had been changed would actually use the currencies that were selected immediately beforehand. This was due to the way the `animate` function was set up in `useAnimationFrame`, and how it was being passed to `requestAnimationFrame`. The function reference passed to `requestAnimationFrame` would only be updated when the actual callback ran, which meant the callback had to run (using the old variables) first before the new animate function, with the newly selected currencies, would be passed into the `requestAnimationFrame` method.
The fix was to make use of `useCallback` and the `useEffect` to actually re-run when the currency values change, forcing the current `requestAnimationFrame` to be unregistered, and a new one to be registered

Further to the fetch being implemented, I've included some basic error handling for a server error, which should handle the 4XX error codes too, as they all appear to include the `detail` property in the response

![image](https://github.com/user-attachments/assets/bf1f9a22-9e15-46b2-a28b-e61ed7501614)

Not evident in the image above, but the progress slider gets disabled if the app is in an error state, because it knows that any re-requests with that same data is going to receive the same error. This is a little bit naive, as the error could have been due to a usage spike on the server, so making a second request a few seconds later might actually work.

I've also taken the liberty of adding an improvement to the experience of using the app. When a user changes the currency, the `fetchData` function is called immediately, and the progress bar is reset. The thinking behind making the fetch immediate is because a user doesn't want to have to wait to see what the conversation rate is, and to start entering their data. In terms of the progress bar being reset, this would save a bit of strain on the server, as it doesn't need to respond to the exact same person, potentially with the exact same data, potentially within just a few seconds (depending on where the progress bar was up to when the user actually made a change). Resetting means the fetches will continue to happen exactly evenly, unless the user changes something, in which case the even spacing re-aligns to that interaction.